### PR TITLE
Homepage: gitlab -> github

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper-compat (= 13),
                pkg-config,
 Standards-Version: 4.6.1.0
 Section: libs
-Homepage: https://gitlab.com/droidian/apt-transport-droidian
+Homepage: https://github.com/droidian/apt-transport-droidian
 Vcs-Git: https://github.com/droidian/apt-transport-droidian.git
 Vcs-Browser: https://github.com/droidian/apt-transport-droidian
 Rules-Requires-Root: no


### PR DESCRIPTION
The Homepage: setting of the control file was pointing at gitlab, whereas in fact the repo. is hosted on github.